### PR TITLE
Update Ci Manifest

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,30 +25,56 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
+
     - name: Build with Maven
       run: mvn package -DskipTests
+
+    - name: Upload jar
+      uses: actions/upload-artifact@v4
+      with:
+          name: performance-app-jar
+          path: ./target/*SNAPSHOT.jar
 
   dockerize:
     needs: build
 
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Login to Github Packages
-      run: |
-        echo ${{ secrets.TOKEN_PUBLISH_PACKAGE }} | docker login --username kon1ch1wa --password-stdin ghcr.io
-    - uses: actions/checkout@v3
-    - name: Build docker image
-      run: |
-        docker build . --tag ghcr.io/kon1ch1wa/performance:latest
-    - uses: actions/checkout@v3
-    - name: Push to container registry in github
-      run: |
-        docker push ghcr.io/kon1ch1wa/performance:latest
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.TOKEN_PUBLISH_PACKAGE }}
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download jar
+        uses: actions/download-artifact@v4
+        with:
+          name: performance-app-jar
+
+      - name: pwd and ls
+        run: pwd && ls -al
+
+      - name: Build multiplatform docker image and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/kon1ch1wa/performance:latest

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,9 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ "master" ]
+    branches:
+      - "master"
+      - "ci"
   pull_request:
     types:
       - opened
@@ -33,3 +35,21 @@ jobs:
     - name: Build with Maven
       run: mvn package -DskipTests
 
+  dockerize:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build docker image
+      run: |
+        docker build . --tag ghcr.io/kon1ch1wa/performance:latest
+
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Publish package
+      run: |
+        docker login --username kon1ch1wa --password ${{ secrets.TOKEN_PUBLISH_PACKAGE }}
+        docker push ghcr.io/kon1ch1wa/performance:latest

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -36,20 +35,20 @@ jobs:
       run: mvn package -DskipTests
 
   dockerize:
+    needs: build
+
     runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/checkout@v3
+    - name: Login to Github Packages
+      run: |
+        echo ${{ secrets.TOKEN_PUBLISH_PACKAGE }} | docker login --username kon1ch1wa --password-stdin ghcr.io
     - uses: actions/checkout@v3
     - name: Build docker image
       run: |
         docker build . --tag ghcr.io/kon1ch1wa/performance:latest
-
-  publish:
-    runs-on: ubuntu-latest
-
-    steps:
     - uses: actions/checkout@v3
-    - name: Publish package
+    - name: Push to container registry in github
       run: |
-        docker login --username kon1ch1wa --password ${{ secrets.TOKEN_PUBLISH_PACKAGE }}
         docker push ghcr.io/kon1ch1wa/performance:latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 HELP.md
+.env
 target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
-FROM maven:latest as build
-WORKDIR /app
-COPY . .
-RUN mvn package -DskipTests
 FROM openjdk:latest as run
-ARG JAR_FILE=app/target/*SNAPSHOT.jar
-WORKDIR /app
-COPY --from=build ${JAR_FILE} performance.jar
-ENTRYPOINT [ "java", "-jar", "performance.jar" ]
+
+COPY ./*SNAPSHOT.jar /usr/local/bin/performance.jar
+
+ENTRYPOINT [ "java", "-jar", "/usr/local/bin/performance.jar" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   app:
-    build: .
+    image: ghcr.io/kon1ch1wa/performance_${ARCH}:latest
     ports:
       - "8080:8080"
     depends_on:

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,11 @@
+docker compose up rabbitmq db
+
+var="$(uname -p)"
+
+if [[ $var=="x86_64" ]]; then
+	echo "ARCH=amd64" > .env
+else
+	echo " ARCH=arm64" > .env
+fi
+
+docker compose up app


### PR DESCRIPTION
Now Docker Image is built from jar just copying it, without building jar inside container.
Now docker compose use image from GitHub Packages instead of building own image from sources.
Now manifest contains 2 jobs: Build (which builds jar and uploading it as artifact) and Dockerize (which downloads jar artifact and build docker image on linux/amd64 and linux/arm64 platforms.